### PR TITLE
Make Tern tooltips better readable

### DIFF
--- a/demos/resources/codemirror/addon/tern/tern.js
+++ b/demos/resources/codemirror/addon/tern/tern.js
@@ -551,7 +551,7 @@
       cm.off("cursorActivity", clear);
       fadeOut(tip);
     }
-    setTimeout(clear, 1700);
+    setTimeout(clear, 5000);
     cm.on("cursorActivity", clear);
   }
 


### PR DESCRIPTION
Increase timeout of the tooltip clear() function to prevent fast disappearing of
the Tern tooltip, which could make clicking on the `[doc]` link hard.