### PR TITLE
Make hint templates with longer text readable

### DIFF
--- a/demos/resources/codemirror-extension/addon/hint/show-hint-eclipse.css
+++ b/demos/resources/codemirror-extension/addon/hint/show-hint-eclipse.css
@@ -19,6 +19,9 @@
   list-style-type: none;
   cursor: pointer;
   white-space: nowrap;
+  display: inline-block;
+  clear: left;
+  float: left;
 }
 
 .CodeMirror-hint-active {


### PR DESCRIPTION
Longer template descriptions were not readable when selected, because the text,
when vertically scrolled, was white on white background. Change items to have
float left and use `inline-block` display to prevent that.