### PR TITLE
Prevent TypeError when hovering over comments

### DIFF
--- a/demos/resources/codemirror-javascript/addon/hint/tern/tern-hover.js
+++ b/demos/resources/codemirror-javascript/addon/hint/tern/tern-hover.js
@@ -17,7 +17,8 @@
   	var pos = d.pos;
   	ts.request(cm, "type", function(error, data) {
       //if (error) return showError(ts, cm, error);
- 
+        if (!data)
+          return;
         var tip = elt("span", null, elt("strong", null, data.type || "not found"));
         if (data.doc)
           tip.appendChild(document.createTextNode(" — " + data.doc));


### PR DESCRIPTION
Add a data falsy check in the tern-hover addon to prevent triggering TypeError
exceptions when hovering over comments.