### PR TITLE
Fix autocompletion bug

### DIFF
--- a/tabris.js
+++ b/tabris.js
@@ -62,7 +62,7 @@
     var cx = infer.cx(), locals = cx.definitions.tabris;    
     var objectName = proto.name, index = objectName.indexOf("!types.");
     if (index == 0) objectName = objectName.substring("!types.".length, objectName.length);
-    objectName = objectName.substring(0, proto.name.indexOf('.')) + 'Properties';
+    objectName = objectName.substring(0, objectName.indexOf('.')) + 'Properties';
     return locals["!properties"].hasProp(objectName);
   }
   
@@ -94,7 +94,7 @@
     var cx = infer.cx(), locals = cx.definitions.tabris;    
     var objectName = proto.name, index = objectName.indexOf("!types.");
     if (index == 0) objectName = objectName.substring("!types.".length, objectName.length);
-    objectName = objectName.substring(0, proto.name.indexOf('.')) + 'Events';
+    objectName = objectName.substring(0, objectName.indexOf('.')) + 'Events';
     return locals["!events"].hasProp(objectName);
   }
   

--- a/test/test_completion.js
+++ b/test/test_completion.js
@@ -60,6 +60,13 @@ exports['test Widget.get completion'] = function() {
     "origin":"ecma5"
   }, null, null, "charAt");
 
+  // get() returns proper types for widgets other than Button
+  util.assertCompletion("var button = tabris.create('Label', {});button.get('text').", {
+    "name":"charAt",
+    "type":"fn(i: number) -> string",
+    "origin":"ecma5"
+  }, null, null, "charAt");
+
   // get('selection') returns a boolean
   /*util.assertCompletion("var button = tabris.create('Button', {});button.get('selection').", {
     "name":"left",


### PR DESCRIPTION
Fix a bug preventing the autocompletion of type-specific string
arguments for most widgets.

Use objectName and not proto.name as substring reference for object and
event properties retrieval, as objectName can get updated with a custom type
in the if-statement and would then not be equivalent to proto.name anymore.