### PR TITLE
Add npm publish script creating a git tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,15 +10,16 @@
     "url": "git://github.com/angelozerr/tern-tabris.git"
   },
   "scripts": {
+    "publish": "node ./scripts/git-tag.js",
     "test": "node ./test/all.js"
-  },    
+  },
   "dependencies": {
     "tern": ">=0.10.0",
     "acorn": ">=1.0.0"
   },
-  "devDependencies": { 
-  	"test": ">=0.0.5" 
-  },  
+  "devDependencies": {
+  	"test": ">=0.0.5"
+  },
   "keywords": [
     "tern",
     "tabris"

--- a/scripts/git-tag.js
+++ b/scripts/git-tag.js
@@ -1,0 +1,59 @@
+(function() {
+  var request = require('request');
+  var prompt = require('prompt');
+  var moduleVersion = require("../package.json").version;
+  var moduleName = require("../package.json").name;
+  var schema = {
+    properties: {
+      "git username": {required: true},
+      "git password": {hidden: true, required: true},
+    }
+  };
+  prompt.start();
+  prompt.get(schema, function (err, result) {
+    if(err) {
+      console.log(err);
+      return;
+    }
+    var gitUsername = result["git username"];
+    var gitPassword = result["git password"];
+    var requestOptions = {
+      url: "https://api.github.com/repos/" + gitUsername + "/" + moduleName + "/releases",
+      headers: {"User-Agent": gitUsername},
+      auth: {
+        user: gitUsername,
+        pass: gitPassword
+      },
+      json: {
+        tag_name: moduleVersion,
+        target_commitish: "master",
+        name: moduleVersion,
+        body: "Version " + moduleVersion
+      }
+    };
+    sendTagRequest(requestOptions);
+  });
+
+  function sendTagRequest(requestOptions) {
+    request.post(requestOptions, function (error, response, body) {
+      if (!error && response.statusCode === 201) {
+        console.log("Successfully created tag " + body.name + ".");
+      } else {
+        logError(error, body);
+      }
+    });
+  }
+
+  function logError(error, body) {
+    if(error) {
+      console.log("Error sending request: " + error);
+      return;
+    }
+    var errorMessage = body && body.message ? body.message : "";
+    var errorCode = body && body.errors && body.errors[0] && body.errors[0].code ? body.errors[0].code : "";
+    console.log("Could not create a release tag" +
+      (errorMessage ? ": " + errorMessage : "") +
+      (errorCode ? ". Error code: " + errorCode : "") +
+      ".");
+  }
+})();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "git-tag",
+  "license": "MIT",
+  "description": "A script creating a GitHub tag. Place in a 'scripts' directory under project root.",
+  "version": "0.0.1",
+  "main": "git-tag.js",
+  "devDependencies": {
+    "prompt": "~0.2.14",
+    "request": "~2.55.0"
+  }
+}


### PR DESCRIPTION
This JS publish script will create a tag based on the current
tern-tabris module version and push it to the git repository.
Beforehand one must execute "npm install" in the scripts
directory to install its module dependencies.

The "publish" hook is executed after the package has been
published, i.e. upon execution of "npm publish".